### PR TITLE
[fp_conversions] Fix `str_to_fp` LSB always being zero

### DIFF
--- a/intro/linux/platform_driver/fp_conversions.h
+++ b/intro/linux/platform_driver/fp_conversions.h
@@ -141,13 +141,13 @@ uint32_t str_to_fp(const char * s, int num_fractional_bits, bool is_signed, size
   // convert the decimal fraction to binary info. 32 is arbitrary, it is the precision of the conversion. extra
   // precision beyond the number of fractional bits in the fixed point num will be truncated off.
   for (i = 0; i < num_fractional_bits; i++) {
+    frac_part_decimal *= 2;
+    accumulator = accumulator << 1;
     // if frac part divided by frac comp is greater than 1, a 1 should be appended to bitstring
     if (frac_part_decimal / frac_comp) {
       accumulator += 0x00000001;
       frac_part_decimal -= frac_comp;
     }
-    frac_part_decimal *= 2;
-    accumulator = accumulator << 1;
   }
   accumulator += int_part_decimal << num_fractional_bits;
   if (is_signed && substring[0] == '-') {


### PR DESCRIPTION
Currently, the value returned by the `str_to_fp()` function would always have an LSB of zero. Although the remaining bits are correctly aligned, this still resulted in an effective fractional precision one bit lower than expected.

This was discovered when attempting to write a value of 0.0625 (`0x01`, in UQ4.4 format) to a particular hardware register, which actually parsed to `0x00`. Further testing revealed this "LSB equals zero" error to be very reliable — for instance, 0.9999 parsed to `0x0E` instead of `0x0F`, and 0.1875 to `0x02` instead of `0x03`.