### PR TITLE
Update drivers for AD1939 and TPA613A2

### DIFF
--- a/examples/passthrough/linux/ad1939/ad1939.c
+++ b/examples/passthrough/linux/ad1939/ad1939.c
@@ -1394,7 +1394,7 @@ uint32_t decode_volume(uint8_t volume_level)
   uint32_t decodedDb = (uint32_t)volume_level;
 
   // Return the shifted and scaled number to keep with convention
-  return (decodedDb<<=16)*3/8;
+  return (decodedDb<<16)*3/8;
 }
 
 /** Tell the kernel what the initialization function is */

--- a/examples/passthrough/linux/ad1939/ad1939.c
+++ b/examples/passthrough/linux/ad1939/ad1939.c
@@ -39,7 +39,7 @@ static dev_t dev_num;
 
 // Function Prototypes
 static int ad1939_probe(struct platform_device *pdev);
-static int ad1939_remove(struct platform_device *pdev);
+static void ad1939_remove(struct platform_device *pdev);
 static ssize_t ad1939_read(struct file *file, char *buffer, size_t len, loff_t *offset);
 static ssize_t ad1939_write(struct file *file, const char *buffer, size_t len, loff_t *offset);
 static int ad1939_open(struct inode *inode, struct file *file);
@@ -126,7 +126,7 @@ MODULE_DEVICE_TABLE(of, al_ad1939_dt_ids);
 static struct platform_driver ad1939_platform =
 {
     .probe = ad1939_probe,
-    .remove = ad1939_remove,
+    .remove_new = ad1939_remove,
     .driver = {
         .name = "Audio Logic ad1939 Driver",
         .owner = THIS_MODULE,
@@ -528,9 +528,8 @@ static ssize_t ad1939_write(struct file *file, const char *buffer, size_t len, l
     leaks.
 
     @param platform_device Pointer to the device structure being deleted
-    @returns SUCCESS
 */
-static int ad1939_remove(struct platform_device *pdev)
+static void ad1939_remove(struct platform_device *pdev)
 {
     // Grab the instance-specific information out of the platform device
     al_ad1939_dev_t *dev = (al_ad1939_dev_t *)platform_get_drvdata(pdev);
@@ -559,7 +558,7 @@ static int ad1939_remove(struct platform_device *pdev)
 
     pr_info("ad1939_remove exit\n");
 
-    return 0;
+    return;
 }
 
 

--- a/examples/passthrough/linux/ad1939/ad1939.c
+++ b/examples/passthrough/linux/ad1939/ad1939.c
@@ -153,8 +153,10 @@ static const struct file_operations al_ad1939_fops =
 static int ad1939_init(void)
 {
     int ret_val = 0;
+    char cmd[3];
     
     // Add the spi master 
+    struct spi_board_info spi_device_info;
     struct spi_master *master;
     
     pr_info("Initializing the Audio Logic ad1939 module\n");
@@ -172,7 +174,7 @@ static int ad1939_init(void)
     ------------------------------------------------------------------*/
     
     // Register the device
-    struct spi_board_info spi_device_info = {
+    spi_device_info = (struct spi_board_info){
         .modalias = "al_ad1939_",     // Needs to be the same as the device name
         .max_speed_hz = speed,
         .bus_num = 1,             // Determined from /sys/class/spi_master                
@@ -213,7 +215,9 @@ static int ad1939_init(void)
 
     printk("\tUnmuting the channels\n");
     // Set the unmute commands
-    char cmd[3] = {0x08,0x00,0x80};
+    cmd[0] = 0x08;
+    cmd[1] = 0x00;
+    cmd[2] = 0x80;
     ret_val = spi_write(spi_device,&cmd, sizeof(cmd));
     //printk("%d\n",ret_val);
 

--- a/examples/passthrough/linux/tpa613a2/tpa613a2.c
+++ b/examples/passthrough/linux/tpa613a2/tpa613a2.c
@@ -903,13 +903,13 @@ uint32_t decode_volume(uint8_t code)
   if (i < PN_INDEX)
   {    
     decodedDB = VolumeLevels[i].value;
-    decodedDB = (decodedDB<<=16)/10;
+    decodedDB = (decodedDB<<16)/10;
     return -1*decodedDB;
   }  
   else
   {
     decodedDB = VolumeLevels[i].value;
-    return (decodedDB<<=16)/10;
+    return (decodedDB<<16)/10;
   }  
 
 

--- a/examples/passthrough/linux/tpa613a2/tpa613a2.c
+++ b/examples/passthrough/linux/tpa613a2/tpa613a2.c
@@ -243,6 +243,7 @@ static int tpa613a2_init(void)
     int ret_val = 0;
     struct i2c_adapter *i2c_adapt;
     struct i2c_board_info i2c_info;
+    char cmd[2];
     
     pr_info("Initializing the Audio Logic tpa613a2 module\n");
 
@@ -284,7 +285,8 @@ static int tpa613a2_init(void)
     //Send some initialization commands
 
     // Enable both channels
-    char cmd[2] = {0x01, 0xc0};
+    cmd[0] = 0x01;
+    cmd[1] = 0xc0;
     i2c_master_send(tpa_i2c_client,&cmd[0],2);
 
     // Set -.3dB gain on both channels (closest value to unity)

--- a/examples/passthrough/linux/tpa613a2/tpa613a2.c
+++ b/examples/passthrough/linux/tpa613a2/tpa613a2.c
@@ -125,7 +125,7 @@ static const unsigned short normal_i2c[]=
 
 // Function Prototypes
 static int tpa613a2_probe(struct platform_device *pdev);
-static int tpa613a2_remove(struct platform_device *pdev);
+static void tpa613a2_remove(struct platform_device *pdev);
 static ssize_t tpa613a2_read(struct file *file, char *buffer, size_t len, loff_t *offset);
 static ssize_t tpa613a2_write(struct file *file, const char *buffer, size_t len, loff_t *offset);
 static int tpa613a2_open(struct inode *inode, struct file *file);
@@ -191,9 +191,9 @@ static int tpa_i2c_probe(struct i2c_client *client,
   return 0;
 }
 
-static int tpa_i2c_remove(struct i2c_client *client)
+static void tpa_i2c_remove(struct i2c_client *client)
 {
-  return 0;
+  return;
 }
 struct i2c_driver tpa_i2c_driver = {
     .driver = { 
@@ -212,7 +212,7 @@ MODULE_DEVICE_TABLE(of, al_tpa613a2_dt_ids);
 static struct platform_driver tpa613a2_platform =
 {
       .probe = tpa613a2_probe,
-      .remove = tpa613a2_remove,
+      .remove_new = tpa613a2_remove,
       .driver = {
       .name = "Audio Logic tpa613a2 Driver",
       .owner = THIS_MODULE,
@@ -496,9 +496,8 @@ static ssize_t tpa613a2_write(struct file *file, const char *buffer, size_t len,
     leaks.
 
     @param platform_device Pointer to the device structure being deleted
-    @returns SUCCESS
 */
-static int tpa613a2_remove(struct platform_device *pdev)
+static void tpa613a2_remove(struct platform_device *pdev)
 {
     // Grab the instance-specific information out of the platform device
     al_tpa613a2_dev_t *dev = (al_tpa613a2_dev_t *)platform_get_drvdata(pdev);
@@ -513,7 +512,7 @@ static int tpa613a2_remove(struct platform_device *pdev)
 
     pr_info("tpa613a2_remove exit\n");
 
-    return 0;
+    return;
 }
 
 


### PR DESCRIPTION
This PR addresses several issues:
- Declarations are code are mixed, violating ISO C90 standards (which the Linux kernel follows)
- Double-modification of a variable occurs, throwing a "sequence-point" warning and possibly creating undefined behavior
- Driver and device removal functions have return values, violating newer kernel standards

While all of these simply cause GCC to throw warnings during compilation, fixing them will help to maintain compatibility with the current 6.1.38-lts kernel.